### PR TITLE
Mutex refresh

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -15,90 +15,23 @@ type Clock interface {
 	Second() int
 }
 
+type ConfHttp struct {
+	Listen string
+	Index  *template.Template
+}
+
+type ConfRefresh struct {
+	Enabled bool
+	At      Clock
+}
+
 type Conf struct {
-	Http struct {
-		Listen string
-		Index  *template.Template
-	}
-
-	Refresh struct {
-		Enabled bool
-		At      Clock
-	}
-
-	Pac *Pac
+	Http    ConfHttp
+	Refresh ConfRefresh
+	Pac     *Pac
 
 	dir     string
 	watches []chan struct{}
-}
-
-func (c *Conf) Watch() <-chan struct{} {
-	watch := make(chan struct{}, 1)
-	c.watches = append(c.watches, watch)
-	return watch
-}
-
-func (c *Conf) Reload() error {
-	cfg, err := ini.Load(c.dir + "/blinky.conf")
-	if err != nil {
-		return err
-	}
-
-	err = c.parseHttp(cfg.Section("http"))
-	if err != nil {
-		return err
-	}
-
-	err = c.parseRefresh(cfg.Section("refresh"))
-	if err != nil {
-		return err
-	}
-
-	for _, watch := range c.watches {
-		watch <- struct{}{}
-	}
-
-	return nil
-}
-
-func (c *Conf) parseHttp(sec *ini.Section) error {
-	var err error
-	if sec.HasKey("listen") {
-		c.Http.Listen = sec.Key("listen").Value()
-	}
-
-	_, _, err = net.SplitHostPort(c.Http.Listen)
-	if err != nil {
-		return err
-	}
-
-	c.Http.Index, err = template.ParseFiles(c.dir + "/index.html.tmpl")
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (c *Conf) parseRefresh(sec *ini.Section) error {
-	var err error
-	if sec.HasKey("enabled") {
-		c.Refresh.Enabled, err = sec.Key("enabled").Bool()
-		if err != nil {
-			return err
-		}
-	}
-
-	if !sec.HasKey("at") {
-		c.Refresh.At, err = time.Parse(hhmm, "02:30")
-	} else {
-		c.Refresh.At, err = sec.Key("at").TimeFormat(hhmm)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func NewConf(dir string) (*Conf, error) {
@@ -117,4 +50,75 @@ func NewConf(dir string) (*Conf, error) {
 	}
 
 	return &conf, nil
+}
+
+func (c *Conf) Watch() <-chan struct{} {
+	watch := make(chan struct{}, 1)
+	c.watches = append(c.watches, watch)
+	return watch
+}
+
+func (c *Conf) Reload() error {
+	cfg, err := ini.Load(c.dir + "/blinky.conf")
+	if err != nil {
+		return err
+	}
+
+	c.Http, err = parseHttp(cfg.Section("http"), c.dir)
+	if err != nil {
+		return err
+	}
+
+	c.Refresh, err = parseRefresh(cfg.Section("refresh"))
+	if err != nil {
+		return err
+	}
+
+	for _, watch := range c.watches {
+		watch <- struct{}{}
+	}
+
+	return nil
+}
+
+func parseHttp(sec *ini.Section, dir string) (ConfHttp, error) {
+	c := ConfHttp{}
+	var err error
+	if sec.HasKey("listen") {
+		c.Listen = sec.Key("listen").Value()
+	}
+
+	_, _, err = net.SplitHostPort(c.Listen)
+	if err != nil {
+		return c, err
+	}
+
+	c.Index, err = template.ParseFiles(dir + "/index.html.tmpl")
+	if err != nil {
+		return c, err
+	}
+
+	return c, nil
+}
+
+func parseRefresh(sec *ini.Section) (ConfRefresh, error) {
+	c := ConfRefresh{}
+	var err error
+	if sec.HasKey("enabled") {
+		c.Enabled, err = sec.Key("enabled").Bool()
+		if err != nil {
+			return c, err
+		}
+	}
+
+	if !sec.HasKey("at") {
+		c.At, err = time.Parse(hhmm, "02:30")
+	} else {
+		c.At, err = sec.Key("at").TimeFormat(hhmm)
+		if err != nil {
+			return c, err
+		}
+	}
+
+	return c, nil
 }

--- a/http.go
+++ b/http.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 )
 
-func Serve(conf *Conf) error {
+func Serve(conf *Conf) {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "GET" || r.URL.Path != "/" {
 			http.NotFound(w, r)
@@ -24,7 +24,30 @@ func Serve(conf *Conf) error {
 		}
 	})
 
-	log.Println("Listening on", conf.Http.Listen)
-	http.ListenAndServe(conf.Http.Listen, nil)
-	return nil
+	confWatch := conf.Watch()
+
+	listenServer := func(addr string) http.Server {
+		srv := http.Server{Addr: addr}
+		go func() {
+			log.Println("Listening on", conf.Http.Listen)
+			err := srv.ListenAndServe()
+			if err != nil {
+				panic(err)
+			}
+		}()
+		return srv
+	}
+
+	srv := listenServer(conf.Http.Listen)
+	for _ = range confWatch {
+		if conf.Http.Listen != srv.Addr {
+			// TODO: why doesn't this stop listening?
+			err := srv.Shutdown(nil)
+			if err != nil {
+				panic(err)
+			}
+
+			srv = listenServer(conf.Http.Listen)
+		}
+	}
 }

--- a/refresh.go
+++ b/refresh.go
@@ -58,6 +58,9 @@ func Refresher(conf *Conf) {
 	timer := time.NewTimer(1 * time.Hour)
 
 	setupTimer := func() {
+		conf.Lock()
+		defer conf.Unlock()
+
 		if conf.Refresh.Enabled {
 			next := nextExecution(conf.Refresh.At)
 			log.Println("Next refresh:", next)

--- a/refresh.go
+++ b/refresh.go
@@ -49,19 +49,35 @@ func nextExecution(target Clock) time.Time {
 }
 
 func Refresher(conf *Conf) {
-	if !conf.Refresh.Enabled {
-		return
-	}
-
 	if !allowsPacmanSync() {
 		log.Println("Cannot run pacman -S. Skipping refresh")
 		return
 	}
 
+	confUpdate := conf.Watch()
+	timer := time.NewTimer(1 * time.Hour)
+
+	setupTimer := func() {
+		if conf.Refresh.Enabled {
+			next := nextExecution(conf.Refresh.At)
+			log.Println("Next refresh:", next)
+			timer.Reset(time.Until(next))
+		} else {
+			timer.Stop()
+		}
+	}
+
+	setupTimer()
+
 	for {
-		next := nextExecution(conf.Refresh.At)
-		log.Println("Next refresh:", next)
-		time.Sleep(time.Until(next))
-		runRefresh()
+		select {
+		case <-confUpdate:
+			timer.Stop()
+			setupTimer()
+		case <-timer.C:
+			timer.Stop()
+			runRefresh()
+			setupTimer()
+		}
 	}
 }


### PR DESCRIPTION
Closes https://github.com/fengb/blinky/issues/5
See also https://github.com/fengb/blinky/pull/8

Main ideas:
- shared mutable `conf`
- mutation protected by mutexes
- easier architecture but hampered by awkwardness and more error prone