### PR TITLE
Simplify snapshot state

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -4,6 +4,7 @@ import (
 	"gopkg.in/ini.v1"
 	"html/template"
 	"net"
+	"time"
 )
 
 const hhmm = "15:04"
@@ -30,7 +31,7 @@ type Conf struct {
 
 	Multicast struct {
 		Listen bool
-		Send   bool
+		Send   time.Duration
 		Addr   string
 		Secret []byte
 	}
@@ -117,7 +118,7 @@ func (c *Conf) parseMulticast(sec *ini.Section) (err error) {
 	}
 
 	if sec.HasKey("send") {
-		c.Multicast.Send, err = sec.Key("send").Bool()
+		c.Multicast.Send, err = sec.Key("send").Duration()
 		if err != nil {
 			return err
 		}

--- a/multicast.go
+++ b/multicast.go
@@ -129,10 +129,10 @@ func (m *Multicast) updateListen(conf *Conf) (*AutoListen, error) {
 }
 
 func (m *Multicast) recv(msg ReadMsg) error {
-	//if m.send != nil && m.send.LocalAddr().String() == msg.Src.String() {
-	//	// We sent this. Ignore!
-	//	continue
-	//}
+	if m.listen.IsListening(msg.Src.String()) {
+		// We sent this. Ignore!
+		return nil
+	}
 
 	snapshot, err := m.decode(msg.Packet)
 	if err != nil {

--- a/multicast.go
+++ b/multicast.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -157,10 +158,19 @@ func (m *Multicast) updateListen(conf *Conf) (*AutoListen, error) {
 				continue
 			}
 
-			err = m.snapshotState.UpdateNetworkLink(msg.Src, msg.Packet, m.decode)
+			snapshot, err := m.decode(msg.Packet)
 			if err != nil {
 				log.Println(err)
 			}
+
+			ipString := msg.Src.IP.String()
+			host, err := net.LookupAddr(ipString)
+			if err != nil {
+				log.Println(err)
+			}
+
+			key := fmt.Sprintf("%s — %s", ipString, host)
+			m.snapshotState.Remote[key] = snapshot
 		}
 	}()
 

--- a/multicast.go
+++ b/multicast.go
@@ -13,8 +13,6 @@ import (
 	"time"
 )
 
-const sendInterval = 30 * time.Second
-
 type Multicast struct {
 	conf          *Conf
 	snapshotState *SnapshotState
@@ -41,7 +39,7 @@ func NewMulticast(conf *Conf, snapshotState *SnapshotState) (*Multicast, error) 
 			if err != nil {
 				log.Println(err)
 			}
-			m.sendTimer.Reset(sendInterval)
+			m.sendTimer.Reset(m.conf.Multicast.Send)
 		}
 	}()
 
@@ -75,7 +73,7 @@ func (m *Multicast) UpdateConf(conf *Conf) error {
 		m.listen = listen
 	}
 
-	if !conf.Multicast.Send {
+	if conf.Multicast.Send <= 0 {
 		m.sendTimer.Stop()
 	}
 

--- a/multicast.go
+++ b/multicast.go
@@ -110,8 +110,12 @@ func (m *Multicast) updateListen(conf *Conf) (*AutoListen, error) {
 }
 
 func (m *Multicast) recv(msg ReadMsg) error {
-	if m.listen.IsListening(msg.Src.String()) {
-		// We sent this. Ignore!
+	weSentThis, err := m.listen.IsListening(msg.Src.String())
+	if err != nil {
+		return err
+	}
+
+	if weSentThis {
 		return nil
 	}
 

--- a/snapshot_state.go
+++ b/snapshot_state.go
@@ -71,6 +71,11 @@ func (s *SnapshotState) UpdateLocal(snapshot *Snapshot) {
 	}
 }
 
+func (s *SnapshotState) UpdateRemote(key string, snapshot *Snapshot) {
+	log.Println("Remote snapshot changed —", key)
+	s.Remote[key] = snapshot
+}
+
 func (s *SnapshotState) SubLocal() <-chan *Snapshot {
 	sub := make(chan *Snapshot)
 	s.subs = append(s.subs, sub)

--- a/snapshot_state.go
+++ b/snapshot_state.go
@@ -47,7 +47,6 @@ func (s *Snapshot) Equal(o *Snapshot) bool {
 type SnapshotState struct {
 	local  *Snapshot
 	Remote map[string]*Snapshot
-	subs   []chan *Snapshot
 }
 
 func NewSnapshotState() *SnapshotState {
@@ -66,18 +65,9 @@ func (s *SnapshotState) UpdateLocal(snapshot *Snapshot) {
 	log.Println("Local snapshot changed")
 
 	s.local = snapshot
-	for _, sub := range s.subs {
-		sub <- snapshot
-	}
 }
 
 func (s *SnapshotState) UpdateRemote(key string, snapshot *Snapshot) {
 	log.Println("Remote snapshot changed —", key)
 	s.Remote[key] = snapshot
-}
-
-func (s *SnapshotState) SubLocal() <-chan *Snapshot {
-	sub := make(chan *Snapshot)
-	s.subs = append(s.subs, sub)
-	return sub
 }

--- a/snapshot_state.go
+++ b/snapshot_state.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"bytes"
 	"log"
-	"net"
-	"sort"
 	"time"
 )
 
@@ -19,14 +16,6 @@ type Snapshot struct {
 	Packages []Package
 }
 
-type NetworkLink struct {
-	Ip          net.IP
-	Hostnames   []string
-	LastContact time.Time
-	Snapshot    *Snapshot
-	raw         []byte
-}
-
 func (s *Snapshot) Status() string {
 	for _, pkg := range s.Packages {
 		if pkg.Upgrade != "" {
@@ -38,7 +27,7 @@ func (s *Snapshot) Status() string {
 
 func (s *Snapshot) Equal(o *Snapshot) bool {
 	if o == nil {
-		return false
+		return s == o
 	}
 
 	if s.LastSync != o.LastSync ||
@@ -56,13 +45,13 @@ func (s *Snapshot) Equal(o *Snapshot) bool {
 }
 
 type SnapshotState struct {
-	local         *Snapshot
-	subs          []chan *Snapshot
-	networkLookup map[string]NetworkLink
+	local  *Snapshot
+	Remote map[string]*Snapshot
+	subs   []chan *Snapshot
 }
 
 func NewSnapshotState() *SnapshotState {
-	return &SnapshotState{networkLookup: make(map[string]NetworkLink)}
+	return &SnapshotState{Remote: make(map[string]*Snapshot)}
 }
 
 func (s *SnapshotState) Local() *Snapshot {
@@ -86,45 +75,4 @@ func (s *SnapshotState) SubLocal() <-chan *Snapshot {
 	sub := make(chan *Snapshot)
 	s.subs = append(s.subs, sub)
 	return sub
-}
-
-func (s *SnapshotState) UpdateNetworkLink(
-	addr *net.UDPAddr,
-	raw []byte,
-	makeSnapshot func(raw []byte) (*Snapshot, error),
-) error {
-	ipString := addr.IP.String()
-	cache, ok := s.networkLookup[ipString]
-	if ok && bytes.Equal(raw, cache.raw) {
-		cache.LastContact = time.Now()
-		s.networkLookup[ipString] = cache
-		return nil
-	}
-
-	snapshot, err := makeSnapshot(raw)
-	if err != nil {
-		return err
-	}
-
-	cache = NetworkLink{raw: raw, Ip: addr.IP, LastContact: time.Now(), Snapshot: snapshot}
-	cache.Hostnames, _ = net.LookupAddr(ipString)
-
-	s.networkLookup[ipString] = cache
-	log.Println("Update received from", ipString)
-
-	return nil
-}
-
-func (s *SnapshotState) Network() []NetworkLink {
-	keys := make([]string, 0, len(s.networkLookup))
-	for key := range s.networkLookup {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	slice := make([]NetworkLink, 0, len(keys))
-	for _, key := range keys {
-		slice = append(slice, s.networkLookup[key])
-	}
-	return slice
 }

--- a/static_files/etc/blinky/blinky.conf
+++ b/static_files/etc/blinky/blinky.conf
@@ -6,6 +6,6 @@ addr=:9012
 
 [multicast]
 listen=true
-send=true
+send=1m
 addr=224.0.0.210:9012
 secret=charliebitmyfinger

--- a/static_files/etc/blinky/index.html.tmpl
+++ b/static_files/etc/blinky/index.html.tmpl
@@ -19,7 +19,7 @@
 </table>
 {{- end }}
 
-{{- range .Network }}
-  <h3>{{ .Ip.String }} &mdash; {{ .Hostnames }}</h3>
-  {{- template "snapshot" .Snapshot }}
+{{- range $name, $snapshot := .Remote }}
+  <h3>{{ $name }}</h3>
+  {{- template "snapshot" $snapshot }}
 {{- end }}


### PR DESCRIPTION
Closes https://github.com/fengb/blinky/issues/25

Reasonable progress to cleanup up the current implementation. No major restructuring yet hopefully it makes the architecture a lot more obvious.

Major changes:
- removed caching from SnapshotState. It's now a simple data store instead of weirdly omniscient about the network
  - Thoughts: maybe it should have caching but generic key based.
  - OTOH, only the network layer really needs caching so it _probably_ belongs in the network instead.
  - Or this is premature optimization. Decoding every 30 seconds shouldn't be expensive. And if we have a rogue node, maybe we should throttle the listener, not the decoding.
- Multicast.send is no longer always connected. This should solve the early connection problem, and also seamlessly fix most broken connections. (closes https://github.com/fengb/blinky/issues/19)
  - Investigate: creating a new UDP connection each time shouldn't be slow, right?
- Multicast.listen detects self broadcast via self IP, instead of sharing the now-defunct send connection. This greatly simplifies the dependency tree.


Followups:
- SnapshotState is a glorified global...
- Read actors / write actors are still not obvious.
- Local / Remote is weirdly split. This might not be possible to fully unify since we should _only_ broadcast local data.